### PR TITLE
Test: 서비스 객체에 대한 단위 테스트 코드 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,10 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    'prettier/prettier': {
-      error: {
-        endOfLine: 'auto',
-      },
-    },
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+  "configurations": [
+    {
+      "type": "chrome",
+      "name": "ws://127.0.0.1:9229/fdd2fa7d-be35-4f55-b037-e64559ff2e1f",
+      "request": "launch",
+      "url": "ws://127.0.0.1:9229/fdd2fa7d-be35-4f55-b037-e64559ff2e1f"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "glob": "^11.0.0",
         "jest": "^29.5.0",
+        "jest-mock": "^29.7.0",
         "prettier": "^3.0.0",
         "replace-in-file": "^8.3.0",
         "source-map-support": "^0.5.21",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
       "json",
       "ts"
     ],
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "glob": "^11.0.0",
     "jest": "^29.5.0",
+    "jest-mock": "^29.7.0",
     "prettier": "^3.0.0",
     "replace-in-file": "^8.3.0",
     "source-map-support": "^0.5.21",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,6 @@ import { AuthModule } from './auth/auth.module';
 import { APP_PIPE } from '@nestjs/core';
 import { CommentsModule } from './comments/comments.module';
 import { Comment } from 'src/comments/entities/comment.entity';
-import { FileController } from './file/file.controller';
 import { FileModule } from './file/file.module';
 import { File } from 'src/file/entities/file.entity';
 import { FileApiService } from './file-api/file-api.service';

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,7 +24,7 @@ import { FileApiService } from './file-api/file-api.service';
     TypeOrmModule.forRoot({
       type: 'postgres',
       host: process.env.DB_HOST,
-      port: parseInt(process.env.DB_PORT, 10),
+      port: parseInt(process.env.DB_PORT || '5432', 10),
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
-import { AuthService } from './auth.service';
+import { MockFunctionMetadata, ModuleMocker } from 'jest-mock';
+
+const moduleMocker = new ModuleMocker(global);
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -8,8 +10,15 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService],
-    }).compile();
+    })
+      .useMocker((token) => {
+        const mockMetaData = moduleMocker.getMetadata(
+          token,
+        ) as MockFunctionMetadata<any, any>;
+        const Mock = moduleMocker.generateFromMetadata(mockMetaData);
+        return new Mock();
+      })
+      .compile();
 
     controller = module.get<AuthController>(AuthController);
   });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -27,7 +27,7 @@ export class AuthController {
 
   @UseInterceptors(ClearJwtTokenInterceptor)
   @Post('signout')
-  signOut(e) {}
+  signOut() {}
 
   @UseInterceptors(CheckAuthorizedInterceptor)
   @Get('me')

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,12 +2,12 @@ import { Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from 'src/users/users.module';
-import { UsersService } from 'src/users/users.service';
+import { SaltRoundsProvider } from './providers/providers';
 
 @Module({
   imports: [UsersModule],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [AuthService, SaltRoundsProvider],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,18 +1,118 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { SALT_ROUNDS_TOKEN } from '../common/constants';
+import * as bcrypt from 'bcrypt';
+import { SaltRoundsProvider } from './providers/providers';
+import { ConfigModule } from '@nestjs/config';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let usersService: Partial<Record<keyof UsersService, jest.Mock>>;
+  let saltRounds: number;
 
   beforeEach(async () => {
+    usersService = {
+      create: jest.fn().mockImplementation((user) => {
+        return Promise.resolve({ id: 1, ...user });
+      }),
+      findOne: jest.fn().mockImplementation((id) => {
+        return Promise.resolve({ id, name: 'Test User' });
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      imports: [
+        await ConfigModule.forRoot({
+          isGlobal: true,
+          envFilePath: '.env',
+        }),
+      ],
+      providers: [
+        AuthService,
+        SaltRoundsProvider,
+        {
+          provide: UsersService,
+          useValue: usersService,
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
+    saltRounds = module.get(SALT_ROUNDS_TOKEN);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('signup', () => {
+    it('should successfully create a new user', async () => {
+      const userDto = {
+        name: 'Test User',
+        password: 'password',
+      };
+
+      await service.signUp(userDto);
+
+      const createdUser = usersService.create.mock.calls[0][0];
+      const isPasswordHashed = await bcrypt.compare(
+        userDto.password,
+        createdUser.password,
+      );
+      expect(isPasswordHashed).toBe(true);
+    });
+
+    it('should throw an error if the user already exists', async () => {
+      const userDto = {
+        name: 'Test User',
+        password: 'password',
+      };
+
+      usersService.create = jest.fn().mockRejectedValue(new Error());
+
+      await expect(service.signUp(userDto)).rejects.toThrow();
+    });
+  });
+
+  describe('signin', () => {
+    it('should successfully sign in a user', async () => {
+      const userDto = {
+        name: 'Test User',
+        password: 'password',
+      };
+
+      usersService.findOne = jest.fn().mockResolvedValue({
+        id: 1,
+        name: userDto.name,
+        password: await bcrypt.hash(userDto.password, saltRounds),
+      });
+
+      const token = await service.signIn(userDto);
+
+      expect(token).toBeDefined();
+    });
+
+    it('should throw an error if the user does not exist', async () => {
+      const userDto = {
+        name: 'Test User',
+        password: 'password',
+      };
+
+      usersService.findOne = jest.fn().mockResolvedValue(null);
+
+      await expect(service.signIn(userDto)).rejects.toThrow();
+    });
+
+    it('should throw an error if the password is incorrect', async () => {
+      const userDto = {
+        name: 'Test User',
+        password: 'password',
+      };
+
+      usersService.findOne = jest.fn().mockResolvedValue({
+        id: 1,
+        name: 'Test User',
+        password: 'hashedPasswordButNotTheSame',
+      });
+
+      await expect(service.signIn(userDto)).rejects.toThrow();
+    });
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -16,8 +16,11 @@ describe('AuthService', () => {
       create: jest.fn().mockImplementation((user) => {
         return Promise.resolve({ id: 1, ...user });
       }),
-      findOne: jest.fn().mockImplementation((id) => {
+      findOneById: jest.fn().mockImplementation((id) => {
         return Promise.resolve({ id, name: 'Test User' });
+      }),
+      findOneByName: jest.fn().mockImplementation((name) => {
+        return Promise.resolve({ id: 1, name });
       }),
     };
 
@@ -51,7 +54,7 @@ describe('AuthService', () => {
 
       await service.signUp(userDto);
 
-      const createdUser = usersService.create.mock.calls[0][0];
+      const createdUser = usersService.create?.mock.calls[0][0];
       const isPasswordHashed = await bcrypt.compare(
         userDto.password,
         createdUser.password,
@@ -78,7 +81,7 @@ describe('AuthService', () => {
         password: 'password',
       };
 
-      usersService.findOne = jest.fn().mockResolvedValue({
+      usersService.findOneByName = jest.fn().mockResolvedValue({
         id: 1,
         name: userDto.name,
         password: await bcrypt.hash(userDto.password, saltRounds),
@@ -95,7 +98,7 @@ describe('AuthService', () => {
         password: 'password',
       };
 
-      usersService.findOne = jest.fn().mockResolvedValue(null);
+      usersService.findOneById = jest.fn().mockResolvedValue(null);
 
       await expect(service.signIn(userDto)).rejects.toThrow();
     });
@@ -106,7 +109,7 @@ describe('AuthService', () => {
         password: 'password',
       };
 
-      usersService.findOne = jest.fn().mockResolvedValue({
+      usersService.findOneById = jest.fn().mockResolvedValue({
         id: 1,
         name: 'Test User',
         password: 'hashedPasswordButNotTheSame',

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import {
-  ConflictException,
   ForbiddenException,
   Inject,
   Injectable,
@@ -29,17 +28,13 @@ export class AuthService {
       password: hashedPassword,
     };
 
-    try {
-      await this.usersService.create(signupDto);
-    } catch (error) {
-      throw new ConflictException('User already exists');
-    }
+    await this.usersService.create(signupDto);
   }
 
   async signIn(userSignInDto: UserSignInDto) {
     const { name, password } = userSignInDto;
 
-    const user = await this.usersService.findOne({ name });
+    const user = await this.usersService.findOneByName(name);
     if (!user) {
       throw new NotFoundException('User not found');
     }
@@ -50,6 +45,10 @@ export class AuthService {
     }
 
     const secret = this.configService.get<string>('SECRET');
+
+    if (!secret) {
+      throw new Error('No secret found');
+    }
 
     return jwt.sign({ id: user.id }, secret, { expiresIn: '365d' });
   }

--- a/src/auth/decorators/get-userid.decorator.ts
+++ b/src/auth/decorators/get-userid.decorator.ts
@@ -4,7 +4,11 @@ import * as jwt from 'jsonwebtoken';
 
 const getPayload = (token: string) => {
   try {
-    return jwt.verify(token, process.env.SECRET) as jwt.JwtPayload;
+    const secret = process.env.SECRET;
+    if (!secret) {
+      throw new Error('SECRET environment variable is not defined');
+    }
+    return jwt.verify(token, secret) as jwt.JwtPayload;
   } catch (e) {
     return null;
   }

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -12,6 +12,9 @@ export class AuthGuard implements CanActivate {
     }
 
     try {
+      if (!process.env.SECRET) {
+        throw new UnauthorizedException('Secret key not defined');
+      }
       const payload = jwt.verify(token, process.env.SECRET);
 
       request.user = payload;

--- a/src/auth/providers/providers.ts
+++ b/src/auth/providers/providers.ts
@@ -1,0 +1,11 @@
+import { SALT_ROUNDS_TOKEN } from '../../common/constants';
+import { ConfigService } from '@nestjs/config';
+
+export const SaltRoundsProvider = {
+  provide: SALT_ROUNDS_TOKEN,
+  useFactory: (configService: ConfigService) => {
+    const envSalt = configService.get<string>('SALT_ROUNDS');
+    return parseInt(envSalt, 10);
+  },
+  inject: [ConfigService],
+};

--- a/src/auth/providers/providers.ts
+++ b/src/auth/providers/providers.ts
@@ -5,6 +5,10 @@ export const SaltRoundsProvider = {
   provide: SALT_ROUNDS_TOKEN,
   useFactory: (configService: ConfigService) => {
     const envSalt = configService.get<string>('SALT_ROUNDS');
+
+    if (!envSalt) {
+      throw new Error('SALT_ROUNDS is not defined');
+    }
     return parseInt(envSalt, 10);
   },
   inject: [ConfigService],

--- a/src/comments/comments.controller.spec.ts
+++ b/src/comments/comments.controller.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CommentsController } from './comments.controller';
+import { MockFunctionMetadata, ModuleMocker } from 'jest-mock';
+
+const moduleMocker = new ModuleMocker(global);
 
 describe('CommentsController', () => {
   let controller: CommentsController;
@@ -7,7 +10,15 @@ describe('CommentsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CommentsController],
-    }).compile();
+    })
+      .useMocker((token) => {
+        const mockMetaData = moduleMocker.getMetadata(
+          token,
+        ) as MockFunctionMetadata<any, any>;
+        const Mock = moduleMocker.generateFromMetadata(mockMetaData);
+        return new Mock();
+      })
+      .compile();
 
     controller = module.get<CommentsController>(CommentsController);
   });

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -29,7 +29,7 @@ export class CommentsController {
   @Get()
   async findAllForThread(
     @Param('threadId', ParseIntPipe) threadId: number,
-    @GetUserId() userId: number,
+    @GetUserId() userId?: number,
   ) {
     const comments = await this.commentsService.findAllForThread(threadId);
 
@@ -39,7 +39,7 @@ export class CommentsController {
   @Get(':commentId')
   async findOne(
     @Param('commentId', ParseIntPipe) commentId: number,
-    @GetUserId() userId: number,
+    @GetUserId() userId?: number,
   ) {
     const comment = await this.commentsService.findOne(commentId);
 
@@ -49,9 +49,9 @@ export class CommentsController {
   @UseGuards(AuthGuard)
   @Post()
   async create(
-    @GetUserId() userId: number,
     @Param('threadId', ParseIntPipe) threadId: number,
     @Body() createCommentDto: CreateCommentDto,
+    @GetUserId() userId: number,
   ) {
     await this.commentsService.create(userId, threadId, createCommentDto);
 
@@ -61,9 +61,9 @@ export class CommentsController {
   @UseGuards(AuthGuard)
   @Put(':commentId')
   async update(
-    @GetUserId() userId: number,
     @Param('commentId', ParseIntPipe) commentId: number,
     @Body() updateCommentDto: UpdateCommentDto,
+    @GetUserId() userId: number,
   ) {
     await this.commentsService.update(userId, commentId, updateCommentDto);
 
@@ -73,8 +73,8 @@ export class CommentsController {
   @UseGuards(AuthGuard)
   @Delete(':commentId')
   async delete(
-    @GetUserId() userId: number,
     @Param('commentId', ParseIntPipe) commentId: number,
+    @GetUserId() userId: number,
   ) {
     await this.commentsService.delete(userId, commentId);
 

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -4,7 +4,6 @@ import {
   Controller,
   Delete,
   Get,
-  Logger,
   Param,
   ParseIntPipe,
   Post,

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -57,7 +57,7 @@ describe('CommentsService', () => {
     };
 
     usersService = {
-      findOne: jest.fn().mockResolvedValue(mockUser),
+      findOneById: jest.fn().mockResolvedValue(mockUser),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -113,7 +113,6 @@ describe('CommentsService', () => {
 
       await service.create(1, 1, createCommentDto);
 
-      expect(usersService.findOne).toHaveBeenCalledWith(1);
       expect(threadsService.findOne).toHaveBeenCalledWith(1);
       expect(commentsRepository.save).toHaveBeenCalledWith({
         content: createCommentDto.content,

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,18 +1,226 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CommentsService } from './comments.service';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Comment } from './entities/comment.entity';
+import { CreateCommentDto } from './dtos/create-comment.dto';
+import { UpdateCommentDto } from './dtos/update-comment.dto';
+import { ThreadsService } from '../threads/threads.service';
+import { UsersService } from 'src/users/users.service';
+import {
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 
 describe('CommentsService', () => {
   let service: CommentsService;
+  let commentsRepository: Partial<Record<keyof Repository<Comment>, jest.Mock>>;
+  let threadsService: Partial<Record<keyof ThreadsService, jest.Mock>>;
+  let usersService: Partial<Record<keyof UsersService, jest.Mock>>;
+
+  const mockUser = {
+    id: 1,
+    name: 'Test User',
+    password: 'password',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockThread = {
+    id: 1,
+    title: 'Test Thread',
+    content: 'Test Content',
+  };
+
+  const mockComment = {
+    id: 1,
+    content: 'Test Comment',
+    user: mockUser,
+    thread: Promise.resolve(mockThread),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isAuthorBy: (userId: number) => userId === mockUser.id,
+  };
 
   beforeEach(async () => {
+    commentsRepository = {
+      find: jest.fn().mockResolvedValue([mockComment]),
+      findOne: jest.fn().mockResolvedValue(mockComment),
+      create: jest.fn().mockImplementation((comment) => comment),
+      save: jest.fn().mockResolvedValue(mockComment),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+
+    threadsService = {
+      findOne: jest.fn().mockResolvedValue(mockThread),
+    };
+
+    usersService = {
+      findOne: jest.fn().mockResolvedValue(mockUser),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CommentsService],
+      providers: [
+        CommentsService,
+        {
+          provide: getRepositoryToken(Comment),
+          useValue: commentsRepository,
+        },
+        {
+          provide: ThreadsService,
+          useValue: threadsService,
+        },
+        {
+          provide: UsersService,
+          useValue: usersService,
+        },
+      ],
     }).compile();
 
     service = module.get<CommentsService>(CommentsService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('findAllForThread', () => {
+    it('should return an array of comments for a given thread', async () => {
+      const result = await service.findAllForThread(1);
+      expect(commentsRepository.find).toHaveBeenCalledWith({
+        where: { thread: { id: 1 } },
+        order: { createdAt: 'DESC' },
+      });
+      expect(result).toEqual([mockComment]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a comment if found', async () => {
+      const comment = await service.findOne(1);
+      expect(commentsRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+      expect(comment).toEqual(mockComment);
+    });
+
+    it('should throw NotFoundException if comment is not found', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue(undefined);
+      await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a comment successfully', async () => {
+      const createCommentDto: CreateCommentDto = { content: 'New comment' };
+
+      await service.create(1, 1, createCommentDto);
+
+      expect(usersService.findOne).toHaveBeenCalledWith(1);
+      expect(threadsService.findOne).toHaveBeenCalledWith(1);
+      expect(commentsRepository.save).toHaveBeenCalledWith({
+        content: createCommentDto.content,
+        user: mockUser,
+        thread: Promise.resolve(),
+      });
+      expect(commentsRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerErrorException if saving comment fails', async () => {
+      commentsRepository.save = jest.fn().mockResolvedValue(null);
+      const createCommentDto: CreateCommentDto = { content: 'New comment' };
+
+      await expect(service.create(1, 1, createCommentDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a comment successfully', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: (userId: number) => userId === mockUser.id,
+      });
+      const updateCommentDto: UpdateCommentDto = { content: 'Updated comment' };
+
+      await service.update(1, 1, updateCommentDto);
+      expect(commentsRepository.update).toHaveBeenCalledWith(1, {
+        ...updateCommentDto,
+      });
+    });
+
+    it('should throw NotFoundException if user is not the author', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: () => false,
+      });
+      const updateCommentDto: UpdateCommentDto = { content: 'Updated comment' };
+
+      await expect(service.update(2, 1, updateCommentDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw InternalServerErrorException if update fails', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: (userId: number) => userId === mockUser.id,
+      });
+      commentsRepository.update = jest.fn().mockResolvedValue({ affected: 0 });
+      const updateCommentDto: UpdateCommentDto = { content: 'Updated comment' };
+
+      await expect(service.update(1, 1, updateCommentDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a comment successfully', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: (userId: number) => userId === mockUser.id,
+      });
+
+      await service.delete(1, 1);
+      expect(commentsRepository.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('should throw NotFoundException if user is not the author', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: () => false,
+      });
+
+      await expect(service.delete(2, 1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw InternalServerErrorException if delete fails', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: (userId: number) => userId === mockUser.id,
+      });
+      commentsRepository.delete = jest.fn().mockResolvedValue({ affected: 0 });
+
+      await expect(service.delete(1, 1)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('getAndCheckIsAuthor', () => {
+    it('should return the comment if user is the author', async () => {
+      const comment = await service.getAndCheckIsAuthor(1, 1);
+      expect(comment).toEqual(mockComment);
+    });
+
+    it('should throw NotFoundException if user is not the author', async () => {
+      commentsRepository.findOne = jest.fn().mockResolvedValue({
+        ...mockComment,
+        isAuthorBy: () => false,
+      });
+
+      await expect(service.getAndCheckIsAuthor(1, 2)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -8,7 +8,6 @@ import { Comment } from 'src/comments/entities/comment.entity';
 import { Repository } from 'typeorm';
 import { CreateCommentDto } from './dtos/create-comment.dto';
 import { UsersService } from 'src/users/users.service';
-import { Thread } from 'src/threads/entities/thread.entity';
 import { UpdateCommentDto } from 'src/comments/dtos/update-comment.dto';
 import { ThreadsService } from '../threads/threads.service';
 

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -36,7 +36,7 @@ export class CommentsService {
     threadId: number,
     createCommentDto: CreateCommentDto,
   ) {
-    const user = await this.usersService.findOne(userId);
+    const user = await this.usersService.findOne({ id: userId });
     const thread = await this.threadsService.findOne(threadId);
 
     const comment = this.commentsRepository.create({

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -36,7 +36,7 @@ export class CommentsService {
     threadId: number,
     createCommentDto: CreateCommentDto,
   ) {
-    const user = await this.usersService.findOne({ id: userId });
+    const user = await this.usersService.findOneById(userId);
     const thread = await this.threadsService.findOne(threadId);
 
     const comment = this.commentsRepository.create({

--- a/src/comments/dtos/comment.response.dto.ts
+++ b/src/comments/dtos/comment.response.dto.ts
@@ -17,7 +17,7 @@ export class CommentResponseDto {
   createdAt: Date;
   updatedAt: Date;
   isAuthor: boolean;
-  constructor(comment: Comment, myId: number) {
+  constructor(comment: Comment, myId?: number) {
     this.isAuthor = comment.isAuthorBy(myId);
     Object.assign(this, comment);
   }
@@ -27,7 +27,7 @@ export class CommentResponseDto {
 }
 
 export class CommentListResponseDto {
-  constructor(comments: Comment[], myId: number) {
+  constructor(comments: Comment[], myId?: number) {
     this.comments = comments.map(
       (comment) => new CommentResponseDto(comment, myId),
     );

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -20,8 +20,9 @@ export class Comment extends BaseEntity {
   })
   thread: Promise<Thread>;
 
-  isAuthorBy(user: User | number) {
-    const userId = typeof user === 'number' ? user : user.id;
+  isAuthorBy(option: User | number | undefined): boolean {
+    const userId = option instanceof User ? option.id : option;
+
     return this.user.id === userId;
   }
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,1 @@
+export const SALT_ROUNDS_TOKEN = 'SALT_ROUNDS';

--- a/src/common/filters/exception.filter.ts
+++ b/src/common/filters/exception.filter.ts
@@ -12,10 +12,9 @@ import { BaseResponseDto } from '../base-response.dto';
 export class AllExceptionsFilter implements ExceptionFilter {
   private logger = new Logger('AllExceptionsFilter');
 
-  catch(exception: unknown, host: ArgumentsHost) {
+  catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
-    const request = ctx.getRequest();
 
     const status =
       exception instanceof HttpException
@@ -27,7 +26,9 @@ export class AllExceptionsFilter implements ExceptionFilter {
         ? exception.message
         : 'Internal server error';
 
-    this.logger.error(`Status: ${status} Error: ${JSON.stringify(message)}`);
+    this.logger.error(
+      `Status: ${status} Error: ${JSON.stringify(exception.message)}`,
+    );
 
     const baseResponse = new BaseResponseDto(status, message, null);
 

--- a/src/file/dtos/file.response.ts
+++ b/src/file/dtos/file.response.ts
@@ -1,7 +1,6 @@
 import { Exclude, Expose, Type } from 'class-transformer';
 import { File } from 'src/file/entities/file.entity';
 import { Thread } from 'src/threads/entities/thread.entity';
-import { User } from '../../users/entities/User.entity';
 
 class FileResponseDto extends File {
   id: number;
@@ -27,9 +26,9 @@ class FileResponseDto extends File {
 }
 
 export class FileListResponseDto {
-  constructor(files: File[], isAuthor: boolean) {
+  constructor(files: File[], userId?: number) {
     this.files = files.map((file) => new FileResponseDto(file));
-    this.isAuthor = isAuthor;
+    this.isAuthor = files[0]?.isAuthorBy(userId) || false;
   }
 
   isAuthor: boolean;

--- a/src/file/entities/file.entity.ts
+++ b/src/file/entities/file.entity.ts
@@ -1,5 +1,5 @@
 import { Thread } from 'src/threads/entities/thread.entity';
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne } from 'typeorm';
 import { User } from '../../users/entities/User.entity';
 import { BaseEntity } from '../../common/entities/base.entity';
 
@@ -33,4 +33,10 @@ export class File extends BaseEntity {
     lazy: true,
   })
   user: Promise<User>;
+
+  isAuthorBy(option?: number | User): boolean {
+    const userId = option instanceof User ? option.id : option;
+
+    return this.userId === userId;
+  }
 }

--- a/src/file/file.controller.spec.ts
+++ b/src/file/file.controller.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FileController } from './file.controller';
+import { MockFunctionMetadata, ModuleMocker } from 'jest-mock';
+
+const moduleMocker = new ModuleMocker(global);
 
 describe('UploadController', () => {
   let controller: FileController;
@@ -7,7 +10,15 @@ describe('UploadController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FileController],
-    }).compile();
+    })
+      .useMocker((token) => {
+        const mockMetaData = moduleMocker.getMetadata(
+          token,
+        ) as MockFunctionMetadata<any, any>;
+        const Mock = moduleMocker.generateFromMetadata(mockMetaData);
+        return new Mock();
+      })
+      .compile();
 
     controller = module.get<FileController>(FileController);
   });

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   ClassSerializerInterceptor,
   Controller,
-  ForbiddenException,
   Get,
   Param,
   ParseIntPipe,
@@ -66,12 +65,11 @@ export class FileController {
   @Get(':threadId')
   async getFiles(
     @Param('threadId', ParseIntPipe) threadId: number,
-    @GetUserId() userId: number,
+    @GetUserId() userId?: number,
   ) {
     const fileList = await this.fileService.getFiles(threadId);
-    await this.threadsService.getAndCheckIsAuthor(threadId, userId);
 
-    return new FileListResponseDto(fileList, true);
+    return new FileListResponseDto(fileList, userId);
   }
 
   @Get('download/:id')
@@ -88,8 +86,8 @@ export class FileController {
   @Post(':threadId/delete')
   async deleteFiles(
     @Param('threadId', ParseIntPipe) threadId: number,
-    @GetUserId() userId: number,
     @Body() dto: FileDeleteDto,
+    @GetUserId() userId?: number,
   ) {
     await this.threadsService.getAndCheckIsAuthor(threadId, userId);
     await this.fileService.deleteFiles(dto.ids);

--- a/src/file/file.service.spec.ts
+++ b/src/file/file.service.spec.ts
@@ -10,6 +10,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
+import { Readable } from 'typeorm/platform/PlatformTools';
 
 describe('FileService', () => {
   let service: FileService;
@@ -85,12 +86,12 @@ describe('FileService', () => {
         path: '/uploads/test-file.jpg',
         size: 12345,
         buffer: Buffer.from([]),
-        stream: null,
+        stream: new Readable(),
       },
     ];
 
     it('should throw BadRequestException if no files are provided', async () => {
-      await expect(service.uploadFiles(null, 1, 1)).rejects.toThrow(
+      await expect(service.uploadFiles([], 1, 1)).rejects.toThrow(
         BadRequestException,
       );
     });
@@ -110,14 +111,14 @@ describe('FileService', () => {
       await service.uploadFiles(fakeFiles, 1, 1);
 
       expect(fileApiService.checkFileExist).toHaveBeenCalledWith(
-        fakeFiles[0].path,
+        fakeFiles[0]!.path,
       );
       expect(threadsService.findOne).toHaveBeenCalledWith(1);
       expect(fileRepository.create).toHaveBeenCalledWith({
-        name: fakeFiles[0].filename,
-        originalName: fakeFiles[0].originalname,
-        path: fakeFiles[0].path,
-        size: fakeFiles[0].size,
+        name: fakeFiles[0]!.filename,
+        originalName: fakeFiles[0]!.originalname,
+        path: fakeFiles[0]!.path,
+        size: fakeFiles[0]!.size,
         threadId: 1,
         userId: 1,
       });

--- a/src/file/file.service.spec.ts
+++ b/src/file/file.service.spec.ts
@@ -1,18 +1,206 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FileService } from './file.service';
+import { Repository, In } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { File } from './entities/file.entity';
+import { ThreadsService } from '../threads/threads.service';
+import { FileApiService } from '../file-api/file-api.service';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 
 describe('FileService', () => {
   let service: FileService;
+  let fileRepository: Partial<Record<keyof Repository<File>, jest.Mock>>;
+  let threadsService: Partial<Record<keyof ThreadsService, jest.Mock>>;
+  let fileApiService: Partial<Record<keyof FileApiService, jest.Mock>>;
+
+  const mockFileEntity = {
+    id: 1,
+    name: 'test-file.jpg',
+    originalName: 'original-test-file.jpg',
+    path: '/uploads/test-file.jpg',
+    size: 12345,
+    threadId: 1,
+    userId: 1,
+  };
+
+  const mockThread = {
+    id: 1,
+    title: 'Test Thread',
+    content: 'Thread content',
+    isAuthorBy: (userId: number) => userId === 1,
+  };
 
   beforeEach(async () => {
+    fileRepository = {
+      create: jest.fn().mockImplementation((file: Partial<File>) => file),
+      save: jest.fn().mockResolvedValue(mockFileEntity),
+      find: jest.fn().mockResolvedValue([mockFileEntity]),
+      findOne: jest.fn().mockResolvedValue(mockFileEntity),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+
+    threadsService = {
+      findOne: jest.fn().mockResolvedValue(mockThread),
+    };
+
+    fileApiService = {
+      checkFileExist: jest.fn(),
+      deleteFiles: jest.fn().mockImplementation((files: File[]) => files),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FileService],
+      providers: [
+        FileService,
+        {
+          provide: getRepositoryToken(File),
+          useValue: fileRepository,
+        },
+        {
+          provide: ThreadsService,
+          useValue: threadsService,
+        },
+        {
+          provide: FileApiService,
+          useValue: fileApiService,
+        },
+      ],
     }).compile();
 
     service = module.get<FileService>(FileService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('uploadFiles', () => {
+    const fakeFiles: Express.Multer.File[] = [
+      {
+        fieldname: 'file',
+        originalname: 'original-test-file.jpg',
+        encoding: '7bit',
+        mimetype: 'image/jpeg',
+        destination: '/uploads',
+        filename: 'test-file.jpg',
+        path: '/uploads/test-file.jpg',
+        size: 12345,
+        buffer: Buffer.from([]),
+        stream: null,
+      },
+    ];
+
+    it('should throw BadRequestException if no files are provided', async () => {
+      await expect(service.uploadFiles(null, 1, 1)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException if the user is not the owner of the thread', async () => {
+      threadsService.findOne = jest.fn().mockResolvedValue({
+        ...mockThread,
+        isAuthorBy: () => false,
+      });
+
+      await expect(service.uploadFiles(fakeFiles, 1, 2)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should upload files successfully', async () => {
+      await service.uploadFiles(fakeFiles, 1, 1);
+
+      expect(fileApiService.checkFileExist).toHaveBeenCalledWith(
+        fakeFiles[0].path,
+      );
+      expect(threadsService.findOne).toHaveBeenCalledWith(1);
+      expect(fileRepository.create).toHaveBeenCalledWith({
+        name: fakeFiles[0].filename,
+        originalName: fakeFiles[0].originalname,
+        path: fakeFiles[0].path,
+        size: fakeFiles[0].size,
+        threadId: 1,
+        userId: 1,
+      });
+      expect(fileRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerErrorException if file saving fails', async () => {
+      fileRepository.save = jest.fn().mockResolvedValue(null);
+      await expect(service.uploadFiles(fakeFiles, 1, 1)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('getFiles', () => {
+    it('should return files for a given thread', async () => {
+      const result = await service.getFiles(1);
+      expect(fileRepository.find).toHaveBeenCalledWith({
+        where: {
+          thread: { id: 1 },
+        },
+        relations: ['thread'],
+      });
+      expect(result).toEqual([mockFileEntity]);
+    });
+  });
+
+  describe('getAndCheckFileExist', () => {
+    it('should return the file if it exists', async () => {
+      const result = await service.getAndCheckFileExist(1);
+      expect(fileRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+      expect(fileApiService.checkFileExist).toHaveBeenCalledWith(
+        mockFileEntity.path,
+      );
+      expect(result).toEqual(mockFileEntity);
+    });
+
+    it('should throw NotFoundException if the file is not found', async () => {
+      fileRepository.findOne = jest.fn().mockResolvedValue(undefined);
+      await expect(service.getAndCheckFileExist(1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('deleteFiles', () => {
+    it('should throw BadRequestException if ids array is empty', async () => {
+      await expect(service.deleteFiles([])).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException if files are not found', async () => {
+      fileRepository.find = jest.fn().mockResolvedValue([]);
+      await expect(service.deleteFiles([1])).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('should throw InternalServerErrorException if deleted files count does not match provided ids', async () => {
+      fileApiService.deleteFiles = jest.fn().mockReturnValue([]);
+      await expect(service.deleteFiles([1])).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(fileRepository.delete).toHaveBeenCalledWith({ id: In([]) });
+    });
+
+    it('should delete files successfully', async () => {
+      fileApiService.deleteFiles = jest.fn().mockReturnValue([mockFileEntity]);
+      fileRepository.delete = jest.fn().mockResolvedValue({ affected: 1 });
+      await service.deleteFiles([1]);
+      expect(fileApiService.deleteFiles).toHaveBeenCalled();
+      expect(fileRepository.delete).toHaveBeenCalledWith({ id: In([1]) });
+    });
+
+    it('should throw InternalServerErrorException if repository delete affects 0 records', async () => {
+      fileApiService.deleteFiles = jest.fn().mockReturnValue([mockFileEntity]);
+      fileRepository.delete = jest.fn().mockResolvedValue({ affected: 0 });
+      await expect(service.deleteFiles([1])).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
   });
 });

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -25,7 +25,7 @@ export class FileService {
     userId: number,
   ) {
     new Logger().log(JSON.stringify(files));
-    if (!files) {
+    if (files.length === 0) {
       throw new BadRequestException('No file uploaded');
     }
 

--- a/src/threads/dtos/thread.response.dto.ts
+++ b/src/threads/dtos/thread.response.dto.ts
@@ -22,10 +22,10 @@ export class ThreadResponseDto {
 
   @Type(() => Author)
   author: Author;
-  constructor(data: Thread, myId: number) {
-    Object.assign(this, data);
-    this.author = data.user;
-    this.isAuthor = data.user.id === myId;
+  constructor(thread: Thread, myId?: number) {
+    Object.assign(this, thread);
+    this.author = thread.user;
+    this.isAuthor = thread.isAuthorBy(myId);
   }
 
   @Exclude()

--- a/src/threads/entities/thread.entity.ts
+++ b/src/threads/entities/thread.entity.ts
@@ -15,7 +15,10 @@ export class Thread extends BaseEntity {
   @Column({ name: 'view_count', default: 0 })
   viewCount: number;
 
-  @ManyToOne(() => User, (user) => user.threads, { eager: true })
+  @ManyToOne(() => User, (user) => user.threads, {
+    eager: true,
+    onDelete: 'CASCADE',
+  })
   user: User;
 
   @OneToMany(() => Comment, (comment) => comment.thread, { lazy: true })
@@ -24,8 +27,9 @@ export class Thread extends BaseEntity {
   @OneToMany(() => File, (file) => file.thread, { lazy: true })
   files: Promise<File[]>;
 
-  isAuthorBy(user: User | number): boolean {
-    const userId = typeof user === 'number' ? user : user.id;
+  isAuthorBy(option?: User | number): boolean {
+    const userId = option instanceof User ? option.id : option;
+
     return this.user.id === userId;
   }
 }

--- a/src/threads/threads.controller.spec.ts
+++ b/src/threads/threads.controller.spec.ts
@@ -1,5 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThreadsController } from './threads.controller';
+import { MockFunctionMetadata, ModuleMocker } from 'jest-mock';
+
+const moduleMocker = new ModuleMocker(global);
 
 describe('ThreadsController', () => {
   let controller: ThreadsController;
@@ -7,7 +10,15 @@ describe('ThreadsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ThreadsController],
-    }).compile();
+    })
+      .useMocker((token) => {
+        const mockMetaData = moduleMocker.getMetadata(
+          token,
+        ) as MockFunctionMetadata<any, any>;
+        const Mock = moduleMocker.generateFromMetadata(mockMetaData);
+        return new Mock();
+      })
+      .compile();
 
     controller = module.get<ThreadsController>(ThreadsController);
   });

--- a/src/threads/threads.controller.ts
+++ b/src/threads/threads.controller.ts
@@ -31,8 +31,8 @@ export class ThreadsController {
   @UseGuards(AuthGuard)
   @Post()
   async create(
-    @GetUserId() userid: number,
     @Body() createThreadDto: CreateThreadDto,
+    @GetUserId() userid: number,
   ) {
     await this.threadsService.create(userid, createThreadDto);
 
@@ -67,7 +67,7 @@ export class ThreadsController {
   @Get(':id')
   async findOne(
     @Param('id', ParseIntPipe) id: number,
-    @GetUserId() userid: number,
+    @GetUserId() userid?: number,
   ): Promise<ThreadResponseDto> {
     const thread = await this.threadsService.findOne(id);
 

--- a/src/threads/threads.service.spec.ts
+++ b/src/threads/threads.service.spec.ts
@@ -62,7 +62,10 @@ describe('ThreadsService', () => {
     };
 
     usersService = {
-      findOne: jest.fn().mockImplementation(() => {
+      findOneById: jest.fn().mockImplementation(() => {
+        return Promise.resolve({ id: 1 });
+      }),
+      findOneByName: jest.fn().mockImplementation(() => {
         return Promise.resolve({ id: 1 });
       }),
     };
@@ -93,7 +96,7 @@ describe('ThreadsService', () => {
       };
 
       await service.create(1, threadDto);
-      expect(usersService.findOne).toHaveBeenCalledWith(1);
+      expect(usersService.findOneById).toHaveBeenCalledWith(1);
       expect(threadsRepository.create).toHaveBeenCalledWith(
         expect.objectContaining(threadDto),
       );

--- a/src/threads/threads.service.spec.ts
+++ b/src/threads/threads.service.spec.ts
@@ -1,18 +1,211 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ThreadsService } from './threads.service';
+import { Thread } from './entities/thread.entity';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CreateThreadDto } from './dtos/create-thread.dto';
+import { UsersService } from '../users/users.service';
+import { User } from '../users/entities/User.entity';
+import { Comment } from '../comments/entities/comment.entity';
+import {
+  ForbiddenException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 
 describe('ThreadsService', () => {
   let service: ThreadsService;
+  let usersService: Partial<Record<keyof UsersService, jest.Mock>>;
+  let threadsRepository: Partial<Record<keyof Repository<Thread>, jest.Mock>>;
+
+  const mockUser: Partial<User> = {
+    id: 1,
+    name: 'test',
+    password: 'test',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    comments: Promise.resolve([] as Comment[]),
+  };
+
+  const mockThreadList = Array.from({ length: 3 }, (_, i) => {
+    const thread = new Thread();
+    thread.id = i + 1;
+    thread.title = `Title ${i + 1}`;
+    thread.content = `Content ${i + 1}`;
+    thread.user = mockUser as User;
+    return thread;
+  });
 
   beforeEach(async () => {
+    threadsRepository = {
+      find: jest.fn().mockImplementation(() => {
+        return Promise.resolve(mockThreadList);
+      }),
+      findOne: jest.fn().mockImplementation(() => {
+        return Promise.resolve(mockThreadList[0]);
+      }),
+      save: jest.fn().mockImplementation((thread) => {
+        return Promise.resolve(thread);
+      }),
+      create: jest.fn().mockImplementation((thread) => {
+        return thread;
+      }),
+      count: jest.fn().mockImplementation(() => {
+        return Promise.resolve(mockThreadList.length);
+      }),
+      update: jest.fn().mockImplementation(() => {
+        return Promise.resolve({ affected: 1 });
+      }),
+      delete: jest.fn().mockImplementation(() => {
+        return Promise.resolve({ affected: 1 });
+      }),
+    };
+
+    usersService = {
+      findOne: jest.fn().mockImplementation(() => {
+        return Promise.resolve({ id: 1 });
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ThreadsService],
+      providers: [
+        ThreadsService,
+        UsersService,
+        {
+          provide: getRepositoryToken(Thread),
+          useValue: threadsRepository,
+        },
+        {
+          provide: UsersService,
+          useValue: usersService,
+        },
+      ],
     }).compile();
 
     service = module.get<ThreadsService>(ThreadsService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('create', () => {
+    it('should create a thread', async () => {
+      const threadDto: CreateThreadDto = {
+        title: 'Title 1',
+        content: 'Content 1',
+      };
+
+      await service.create(1, threadDto);
+      expect(usersService.findOne).toHaveBeenCalledWith(1);
+      expect(threadsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining(threadDto),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a thread', async () => {
+      const thread = await service.findOne(1);
+      expect(thread).toEqual(mockThreadList[0]);
+    });
+
+    it('should throw an error if thread is not found', async () => {
+      threadsRepository.findOne = jest.fn().mockImplementation(() => {
+        return Promise.resolve(undefined);
+      });
+
+      try {
+        await service.findOne(1);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return a list of threads', async () => {
+      const threads = await service.findAll();
+      expect(threads).toEqual({
+        threads: mockThreadList,
+        totalPage: 1,
+      });
+    });
+
+    it('should return a list of threads with pagination', async () => {
+      const threads = await service.findAll(1, 2);
+      expect(threads).toEqual({
+        threads: mockThreadList,
+        totalPage: 2,
+      });
+    });
+
+    it('should return an empty list if no threads are found', async () => {
+      threadsRepository.find = jest.fn().mockImplementation(() => {
+        return Promise.resolve([]);
+      });
+
+      const threads = await service.findAll();
+      expect(threads).toEqual({
+        threads: [],
+        totalPage: 1,
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should update a thread', async () => {
+      const threadDto: CreateThreadDto = {
+        title: 'Title 1',
+        content: 'Content 1',
+      };
+
+      await service.update(1, threadDto, 1);
+      expect(threadsRepository.update).toHaveBeenCalledWith(1, threadDto);
+    });
+
+    it('should throw an error if the user is not the author', async () => {
+      threadsRepository.update = jest.fn().mockImplementation(() => {
+        return Promise.resolve({ affected: 0 });
+      });
+
+      try {
+        await service.update(1, {} as CreateThreadDto, 1);
+      } catch (error) {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toBe('Failed to update thread');
+      }
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a thread', async () => {
+      await service.delete(1, 1);
+      expect(threadsRepository.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('should throw an error if the user is not the author', async () => {
+      threadsRepository.delete = jest.fn().mockImplementation(() => {
+        return Promise.resolve({ affected: 0 });
+      });
+
+      try {
+        await service.delete(1, 1);
+      } catch (error) {
+        expect(error).toBeInstanceOf(InternalServerErrorException);
+        expect(error.message).toBe('Failed to delete thread');
+      }
+    });
+  });
+
+  describe('getAndCheckIsAuthor', () => {
+    it('should return a thread', async () => {
+      const thread = await service.getAndCheckIsAuthor(1, 1);
+      expect(thread).toEqual(mockThreadList[0]);
+    });
+
+    it('should throw an error if the user is not the author', async () => {
+      try {
+        await service.getAndCheckIsAuthor(1, 2);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ForbiddenException);
+      }
+    });
   });
 });

--- a/src/threads/threads.service.ts
+++ b/src/threads/threads.service.ts
@@ -52,7 +52,11 @@ export class ThreadsService {
 
   async update(id: number, UpdateThreadDto: UpdateThreadDto, authorId: number) {
     await this.getAndCheckIsAuthor(id, authorId);
-    await this.threadRepository.update(id, UpdateThreadDto);
+    const result = await this.threadRepository.update(id, UpdateThreadDto);
+
+    if (result.affected === 0) {
+      throw new InternalServerErrorException('Failed to update thread');
+    }
   }
 
   async delete(id: number, authorId: number) {

--- a/src/users/entities/User.entity.ts
+++ b/src/users/entities/User.entity.ts
@@ -1,13 +1,7 @@
 import { Thread } from 'src/threads/entities/thread.entity';
 import { Comment } from 'src/comments/entities/comment.entity';
 
-import {
-  Column,
-  CreateDateColumn,
-  Entity,
-  OneToMany,
-  PrimaryGeneratedColumn,
-} from 'typeorm';
+import { Column, Entity, OneToMany } from 'typeorm';
 import { File } from '../../file/entities/file.entity';
 import { BaseEntity } from '../../common/entities/base.entity';
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,18 +1,68 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
+import { Repository } from 'typeorm';
+import { User } from './entities/User.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let usersRepository: Partial<Record<keyof Repository<User>, jest.Mock>>;
+
+  const mockUser: Partial<User> = {
+    id: 1,
+    name: 'test',
+    password: 'test',
+  };
 
   beforeEach(async () => {
+    usersRepository = {
+      findOneBy: jest.fn().mockImplementation(() => {
+        return Promise.resolve(mockUser);
+      }),
+      save: jest.fn().mockImplementation((user) => {
+        return Promise.resolve(user);
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('findOne', () => {
+    it('should return a user', async () => {
+      const user = await service.findOne(1);
+      expect(user).toEqual(mockUser);
+      expect(usersRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('should throw an error if user is not found', async () => {
+      usersRepository.findOneBy = jest.fn().mockImplementation(() => {
+        return Promise.resolve(undefined);
+      });
+
+      try {
+        await service.findOne(1);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
+    });
+  });
+
+  describe('create', () => {
+    it('should create a user', async () => {
+      const user = await service.create(mockUser as User);
+      expect(user).toEqual(mockUser);
+      expect(usersRepository.save).toHaveBeenCalled();
+    });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { User } from './entities/User.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException } from '@nestjs/common';
+import { UserSignUpDto } from 'src/auth/dto/user-signup.dto';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -17,6 +18,10 @@ describe('UsersService', () => {
 
   beforeEach(async () => {
     usersRepository = {
+      create: jest.fn().mockImplementation((signupDto: UserSignUpDto) => ({
+        id: 1,
+        ...signupDto,
+      })),
       findOneBy: jest.fn().mockImplementation(() => {
         return Promise.resolve(mockUser);
       }),
@@ -40,7 +45,7 @@ describe('UsersService', () => {
 
   describe('findOne', () => {
     it('should return a user', async () => {
-      const user = await service.findOne(1);
+      const user = await service.findOneById(1);
       expect(user).toEqual(mockUser);
       expect(usersRepository.findOneBy).toHaveBeenCalledWith({ id: 1 });
     });
@@ -51,7 +56,7 @@ describe('UsersService', () => {
       });
 
       try {
-        await service.findOne(1);
+        await service.findOneById(1);
       } catch (error) {
         expect(error).toBeInstanceOf(NotFoundException);
       }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { User } from 'src/users/entities/User.entity';
+import { User } from './entities/User.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
@@ -20,7 +20,7 @@ export class UsersService {
     });
 
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundException('User not found');
     }
 
     return user;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/User.entity';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
+import { UserSignUpDto } from '../auth/dto/user-signup.dto';
 
 @Injectable()
 export class UsersService {
@@ -10,14 +11,21 @@ export class UsersService {
     private usersRepository: Repository<User>,
   ) {}
 
-  async create(user: User): Promise<User> {
+  async create(user: UserSignUpDto): Promise<User> {
     return this.usersRepository.save(user);
   }
 
-  findOne(userId: number): Promise<User> {
-    const user = this.usersRepository.findOneBy({
-      id: userId,
-    });
+  async findOne(idOrOptions: number | FindOptionsWhere<User>): Promise<User> {
+    const userId = typeof idOrOptions === 'number' && idOrOptions;
+    const options = typeof idOrOptions === 'object' && idOrOptions;
+
+    let user: User;
+
+    if (userId) {
+      user = await this.usersRepository.findOneBy({ id: userId });
+    } else if (options) {
+      user = await this.usersRepository.findOneBy(options);
+    }
 
     if (!user) {
       throw new NotFoundException('User not found');

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/User.entity';
-import { FindOptionsWhere, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { UserSignUpDto } from '../auth/dto/user-signup.dto';
 
 @Injectable()
@@ -11,21 +11,24 @@ export class UsersService {
     private usersRepository: Repository<User>,
   ) {}
 
-  async create(user: UserSignUpDto): Promise<User> {
+  async create(signUpDto: UserSignUpDto): Promise<User> {
+    const user = this.usersRepository.create(signUpDto);
+
     return this.usersRepository.save(user);
   }
 
-  async findOne(idOrOptions: number | FindOptionsWhere<User>): Promise<User> {
-    const userId = typeof idOrOptions === 'number' && idOrOptions;
-    const options = typeof idOrOptions === 'object' && idOrOptions;
+  async findOneByName(name: string): Promise<User> {
+    const user = await this.usersRepository.findOneBy({ name });
 
-    let user: User;
-
-    if (userId) {
-      user = await this.usersRepository.findOneBy({ id: userId });
-    } else if (options) {
-      user = await this.usersRepository.findOneBy(options);
+    if (!user) {
+      throw new NotFoundException('User not found');
     }
+
+    return user;
+  }
+
+  async findOneById(id: number): Promise<User> {
+    const user = await this.usersRepository.findOneBy({ id });
 
     if (!user) {
       throw new NotFoundException('User not found');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,13 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
-    "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호
close #13 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 단위 테스트 추가
각 서비스 객체에 대해 단위 테스트를 추가했습니다.

서비스가 의존하는 모든 객체를 목업 데이터로 만들어 DI 서브트리를 만들고 테스트를 진행했습니다.

```ts
// auth service 테스트를 위해 users Service 모킹
usersService = {
      create: jest.fn().mockImplementation((user) => {
        return Promise.resolve({ id: 1, ...user });
      }),
      findOne: jest.fn().mockImplementation((id) => {
        return Promise.resolve({ id, name: 'Test User' });
      }),
    };

   // DI 트리 생성
    const module: TestingModule = await Test.createTestingModule({
      imports: [
        await ConfigModule.forRoot({
          isGlobal: true,
          envFilePath: '.env',
        }),
      ],
      providers: [
        AuthService,
        SaltRoundsProvider, 
        // 모킹한 객체를 di 트리에 제공
        {
          provide: UsersService,
          useValue: usersService,
        },
      ],
    }).compile();
```
### saltRoundsProvider 생성
saltRoundsProvider 를 생성해 salt env 데이터를 di 에 제공하도록 했습니다.
테스트 코드 작성시 salt 값이 직접 지정 되어있었지만, 가독성과 상수 관리와 provider 관리를 한곳에 모아서 하기 위한 목적으로  진행했습니다.

```ts
// salt rounds provider
import { SALT_ROUNDS_TOKEN } from '../../common/constants';
import { ConfigService } from '@nestjs/config';

export const SaltRoundsProvider = {
  provide: SALT_ROUNDS_TOKEN,
  useFactory: (configService: ConfigService) => {
    const envSalt = configService.get<string>('SALT_ROUNDS');
    return parseInt(envSalt, 10);
  },
  inject: [ConfigService],
};

// 사용시

  providers: [
    AuthService,
    SaltRoundsProvider,
// ...
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
