### PR TITLE
Refactor: respository 를 raw 쿼리로 작동되게 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
         "@types/bcrypt": "^5.0.2",
+        "@types/cookie-parser": "^1.4.8",
         "@types/express": "^4.17.21",
         "@types/glob": "^8.1.0",
         "@types/jest": "^29.5.2",
@@ -2009,6 +2010,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.8.tgz",
+      "integrity": "sha512-l37JqFrOJ9yQfRQkljb41l0xVphc7kg5JTjjr+pLRZ0IyZ49V4BQ8vbF4Ut2C2e+WH4al3xD3ZwYwIUfnbT4NQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cookiejar": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/bcrypt": "^5.0.2",
+    "@types/cookie-parser": "^1.4.8",
     "@types/express": "^4.17.21",
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.2",

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Delete,
   Get,
+  Logger,
   Param,
   ParseIntPipe,
   Post,

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -4,7 +4,6 @@ import {
   Controller,
   Delete,
   Get,
-  Logger,
   Param,
   ParseIntPipe,
   Post,

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -5,11 +5,18 @@ import { CommentsService } from './comments.service';
 import { CommentsController } from './comments.controller';
 import { UsersModule } from 'src/users/users.module';
 import { ThreadsModule } from '../threads/threads.module';
+import { CommentsRepository } from 'src/comments/repositories/comments.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment]), UsersModule, ThreadsModule],
-  providers: [CommentsService],
+  providers: [CommentsService, CommentsRepository],
   controllers: [CommentsController],
-  exports: [CommentsService, TypeOrmModule, UsersModule, ThreadsModule],
+  exports: [
+    CommentsService,
+    TypeOrmModule,
+    UsersModule,
+    ThreadsModule,
+    CommentsRepository,
+  ],
 })
 export class CommentsModule {}

--- a/src/comments/dtos/comment.response.dto.ts
+++ b/src/comments/dtos/comment.response.dto.ts
@@ -19,6 +19,7 @@ export class CommentResponseDto {
   isAuthor: boolean;
   constructor(comment: Comment, myId?: number) {
     this.isAuthor = comment.isAuthorBy(myId);
+    this.createdAt = comment['createdAt'];
     Object.assign(this, comment);
   }
 

--- a/src/comments/repositories/comments.repository.ts
+++ b/src/comments/repositories/comments.repository.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Comment } from 'src/comments/entities/comment.entity';
+import { Thread } from 'src/threads/entities/thread.entity';
+import { User } from 'src/users/entities/User.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CommentsRepository {
+  constructor(
+    @InjectRepository(Comment) private readonly repository: Repository<Comment>,
+  ) {}
+
+  async create(comment: Partial<Comment>, user: User, thread: Thread) {
+    const newComment = this.repository.create({
+      ...comment,
+      user,
+    });
+
+    newComment.thread = Promise.resolve(thread);
+
+    return await this.repository.save(newComment);
+  }
+
+  async findByThreadId(threadId: number, createdAt: 'ASC' | 'DESC') {
+    const comments = await this.repository.query(
+      `SELECT "comment".*, 
+        json_build_object(
+          'id', "u".id,
+          'name', "u".name,
+          'password', "u".password
+        ) as "user" FROM "comment"
+        inner join "user" as "u" on "comment"."userId" = "u"."id" 
+        WHERE "threadId" = ${threadId} ORDER BY "createdAt" ${createdAt}`,
+    );
+
+    return this.repository.create(comments);
+  }
+
+  async findOneById(commentId: number) {
+    const comment = await this.repository.query(
+      `SELECT "comment".*,
+        json_build_object(
+          'id', "u".id,
+          'name', "u".name,
+          'password', "u".password
+        ) as "user" FROM "comment" inner join "user" as "u"
+        on "comment"."userId" = "u"."id" 
+        WHERE "comment"."id" = ${commentId}`,
+    );
+
+    return this.repository.create(comment)[0];
+  }
+
+  async update(commentId: number, comment: Partial<Comment>) {
+    const setValuesString = Object.entries(comment)
+      .map(([key, value]) => `${key} = '${value}'`)
+      .join(', ');
+
+    const result = await this.repository.query(
+      `update "comment" set ${setValuesString} where "id" = ${commentId} returning *`,
+    );
+
+    return { affected: result[1] };
+  }
+
+  async delete(commentId: number) {
+    const result = await this.repository.query(
+      `delete from "comment" where "id" = ${commentId}`,
+    );
+
+    return { affected: result[1] };
+  }
+}

--- a/src/comments/repositories/comments.repository.ts
+++ b/src/comments/repositories/comments.repository.ts
@@ -12,14 +12,11 @@ export class CommentsRepository {
   ) {}
 
   async create(comment: Partial<Comment>, user: User, thread: Thread) {
-    const newComment = this.repository.create({
-      ...comment,
-      user,
-    });
+    const newComment = await this.repository.query(
+      `insert into "comment" ("content", "userId", "threadId") values ('${comment.content}', ${user.id}, ${thread.id}) returning *`,
+    );
 
-    newComment.thread = Promise.resolve(thread);
-
-    return await this.repository.save(newComment);
+    return this.repository.create(newComment)[0];
   }
 
   async findByThreadId(threadId: number, createdAt: 'ASC' | 'DESC') {

--- a/src/common/entities/base.entity.ts
+++ b/src/common/entities/base.entity.ts
@@ -11,14 +11,12 @@ export class BaseEntity {
   id: number;
 
   @CreateDateColumn({
-    name: 'created_at',
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 
   @UpdateDateColumn({
-    name: 'updated_at',
     type: 'timestamp',
     default: () => 'CURRENT_TIMESTAMP',
   })

--- a/src/common/filters/exception.filter.ts
+++ b/src/common/filters/exception.filter.ts
@@ -27,7 +27,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         : 'Internal server error';
 
     this.logger.error(
-      `Status: ${status} Error: ${JSON.stringify(exception.message)}`,
+      `Status: ${status} Error: ${JSON.stringify(exception.message)} Stack: ${exception.stack}`,
     );
 
     const baseResponse = new BaseResponseDto(status, message, null);

--- a/src/common/interceptors/response.interceptor.ts
+++ b/src/common/interceptors/response.interceptor.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
 import { map, Observable } from 'rxjs';
 import { BaseResponseDto } from '../base-response.dto';

--- a/src/common/interceptors/response.interceptor.ts
+++ b/src/common/interceptors/response.interceptor.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
 import { map, Observable } from 'rxjs';
 import { BaseResponseDto } from '../base-response.dto';

--- a/src/file/dtos/file.response.ts
+++ b/src/file/dtos/file.response.ts
@@ -26,9 +26,9 @@ class FileResponseDto extends File {
 }
 
 export class FileListResponseDto {
-  constructor(files: File[], userId?: number) {
+  constructor(files: File[], isAuthor: boolean) {
     this.files = files.map((file) => new FileResponseDto(file));
-    this.isAuthor = files[0]?.isAuthorBy(userId) || false;
+    this.isAuthor = isAuthor;
   }
 
   isAuthor: boolean;

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -68,8 +68,11 @@ export class FileController {
     @GetUserId() userId?: number,
   ) {
     const fileList = await this.fileService.getFiles(threadId);
+    const thread = await this.threadsService.findOne(threadId);
 
-    return new FileListResponseDto(fileList, userId);
+    const isAuthor = thread.isAuthorBy(userId);
+
+    return new FileListResponseDto(fileList, isAuthor);
   }
 
   @Get('download/:id')

--- a/src/file/file.module.ts
+++ b/src/file/file.module.ts
@@ -3,14 +3,14 @@ import { FileController } from 'src/file/file.controller';
 import { FileService } from './file.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { File } from 'src/file/entities/file.entity';
-import { ThreadsService } from 'src/threads/threads.service';
 import { ThreadsModule } from '../threads/threads.module';
 import { FileApiService } from '../file-api/file-api.service';
 import { UsersModule } from '../users/users.module';
+import { FileRepository } from 'src/file/repositories/fileRepository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([File]), ThreadsModule, UsersModule],
   controllers: [FileController],
-  providers: [FileService, FileApiService, ThreadsService],
+  providers: [FileService, FileApiService, FileRepository],
 })
 export class FileModule {}

--- a/src/file/repositories/fileRepository.ts
+++ b/src/file/repositories/fileRepository.ts
@@ -10,14 +10,12 @@ export class FileRepository {
     private readonly fileRepository: Repository<File>,
   ) {}
 
-  create(file: Partial<File>, userId: number, threadId: number) {
-    const newFile = this.fileRepository.create({
-      ...file,
-      userId,
-      threadId,
-    });
+  async create(file: Partial<File>, userId: number, threadId: number) {
+    const newFile = await this.fileRepository.query(
+      `insert into "file" ("name", "originalName", "path", "size", "userId", "threadId") values ('${file.name}', '${file.originalName}', '${file.path}', ${file.size}, ${userId}, ${threadId}) returning *`,
+    );
 
-    return this.fileRepository.save(newFile);
+    return this.fileRepository.create(newFile)[0];
   }
 
   async findByThreadId(threadId: number) {

--- a/src/file/repositories/fileRepository.ts
+++ b/src/file/repositories/fileRepository.ts
@@ -27,9 +27,9 @@ export class FileRepository {
         'id', "thread".id,
         'title', "thread".title,
         'content', "thread".content,
-        'createdAt', "thread".created_at,
-        'updatedAt', "thread".updated_at,
-        'viewCount', "thread".view_count
+        'createdAt', "thread"."createdAt",
+        'updatedAt', "thread"."updatedAt",
+        'viewCount', "thread"."viewCount"
       ) as "thread"
       from "file" inner join "thread" on "thread"."id" = "file"."threadId"
       where "thread"."id" = ${threadId}`,

--- a/src/file/repositories/fileRepository.ts
+++ b/src/file/repositories/fileRepository.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { File } from 'src/file/entities/file.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class FileRepository {
+  constructor(
+    @InjectRepository(File)
+    private readonly fileRepository: Repository<File>,
+  ) {}
+
+  create(file: Partial<File>, userId: number, threadId: number) {
+    const newFile = this.fileRepository.create({
+      ...file,
+      userId,
+      threadId,
+    });
+
+    return this.fileRepository.save(newFile);
+  }
+
+  async findByThreadId(threadId: number) {
+    const files = await this.fileRepository.query(
+      `
+      select "file".*, json_build_object(
+        'id', "thread".id,
+        'title', "thread".title,
+        'content', "thread".content,
+        'createdAt', "thread".created_at,
+        'updatedAt', "thread".updated_at,
+        'viewCount', "thread".view_count
+      ) as "thread"
+      from "file" inner join "thread" on "thread"."id" = "file"."threadId"
+      where "thread"."id" = ${threadId}`,
+    );
+
+    return this.fileRepository.create(files);
+  }
+
+  async findOneById(id: number) {
+    const file = await this.fileRepository.query(
+      `select * from "file" where id = ${id}`,
+    );
+
+    return this.fileRepository.create(file)[0];
+  }
+
+  async findByIds(ids: number[]) {
+    const files = await this.fileRepository.query(
+      `select * from "file" where id in (${ids.join(',')})`,
+    );
+
+    return this.fileRepository.create(files);
+  }
+
+  async deleteByIds(ids: number[]) {
+    const result = await this.fileRepository.query(
+      `delete from "file" where id in (${ids.join(',')}) returning *`,
+    );
+
+    if (result[1] !== ids.length) {
+      return { affected: 0 };
+    }
+
+    return { affected: result[1] };
+  }
+}

--- a/src/threads/dtos/thread.response.dto.ts
+++ b/src/threads/dtos/thread.response.dto.ts
@@ -1,4 +1,4 @@
-import { Exclude, Expose, Type } from 'class-transformer';
+import { Exclude, Type } from 'class-transformer';
 import { Thread } from 'src/threads/entities/thread.entity';
 import { User } from 'src/users/entities/User.entity';
 import { Comment } from 'src/comments/entities/comment.entity';

--- a/src/threads/entities/thread.entity.ts
+++ b/src/threads/entities/thread.entity.ts
@@ -1,7 +1,7 @@
 import { User } from 'src/users/entities/User.entity';
 import { Comment } from 'src/comments/entities/comment.entity';
 import { File } from 'src/file/entities/file.entity';
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 import { BaseEntity } from '../../common/entities/base.entity';
 
 @Entity()
@@ -12,13 +12,12 @@ export class Thread extends BaseEntity {
   @Column({ length: 255, nullable: true })
   content: string;
 
-  @Column({ name: 'view_count', default: 0 })
+  @Column({ default: 0 })
   viewCount: number;
   @ManyToOne(() => User, (user) => user.threads, {
     eager: true,
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'user_id' })
   user: User;
 
   @OneToMany(() => Comment, (comment) => comment.thread, { lazy: true })

--- a/src/threads/entities/thread.entity.ts
+++ b/src/threads/entities/thread.entity.ts
@@ -1,7 +1,7 @@
 import { User } from 'src/users/entities/User.entity';
 import { Comment } from 'src/comments/entities/comment.entity';
 import { File } from 'src/file/entities/file.entity';
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { BaseEntity } from '../../common/entities/base.entity';
 
 @Entity()
@@ -14,11 +14,11 @@ export class Thread extends BaseEntity {
 
   @Column({ name: 'view_count', default: 0 })
   viewCount: number;
-
   @ManyToOne(() => User, (user) => user.threads, {
     eager: true,
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'user_id' })
   user: User;
 
   @OneToMany(() => Comment, (comment) => comment.thread, { lazy: true })

--- a/src/threads/repositories/threadsRepository.ts
+++ b/src/threads/repositories/threadsRepository.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Thread } from 'src/threads/entities/thread.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class ThreadsRepository {
+  constructor(
+    @InjectRepository(Thread) private threadsRepository: Repository<Thread>,
+  ) {}
+
+  async create(thread: Partial<Thread>): Promise<Thread> {
+    const newThread = this.threadsRepository.create(thread);
+
+    return this.threadsRepository.save(newThread);
+  }
+
+  async save(thread: Thread): Promise<Thread> {
+    return this.threadsRepository.save(thread);
+  }
+
+  async findOneById(id: number): Promise<Thread | undefined> {
+    const threads = await this.threadsRepository.query(
+      `select "thread".*, json_build_object(
+        'id', "u".id,
+        'username', "u".name,
+        'password', "u".password
+      ) as "user" from "thread" inner join "user" as "u" on "thread"."user_id" = "u"."id" where "thread"."id" = ${id}`,
+    );
+
+    return this.threadsRepository.create(threads)[0];
+  }
+
+  async findForPagination(
+    page: number,
+    limit: number,
+    search: string,
+    createdAt: 'ASC' | 'DESC',
+  ): Promise<Thread[]> {
+    const threads = await this.threadsRepository.query(
+      `
+      select 
+        "thread".*, 
+        json_build_object(
+          'id', "u".id,
+          'username', "u".name,
+          'password', "u".password
+        ) as "user"
+      from "thread" 
+      inner join "user" as "u" on "thread"."user_id" = "u"."id"
+      where "thread"."title" like '%${search}%'
+      order by "thread"."created_at" ${createdAt} 
+      limit ${limit} offset ${page * limit}
+      `,
+    );
+
+    return this.threadsRepository.create(threads);
+  }
+
+  async count() {
+    return this.threadsRepository.query('select count(*) from "thread"');
+  }
+
+  async update(
+    id: number,
+    thread: Partial<Thread>,
+  ): Promise<{ affected: number }> {
+    const valuesString = Object.entries(thread)
+      .map(([key, value]) => {
+        return `${key} = '${value}'`;
+      })
+      .join(', ');
+
+    const result = await this.threadsRepository.query(
+      `update "thread" set ${valuesString} where "id" = ${id} returning *`,
+    );
+
+    if (!result) {
+      return { affected: 0 };
+    }
+
+    return { affected: 1 };
+  }
+
+  async delete(id: number): Promise<{ affected: number }> {
+    const result = await this.threadsRepository.query(
+      `delete from "thread" where "id" = ${id} returning *`,
+    );
+
+    if (!result) {
+      return { affected: 0 };
+    }
+
+    return { affected: 1 };
+  }
+}

--- a/src/threads/repositories/threadsRepository.ts
+++ b/src/threads/repositories/threadsRepository.ts
@@ -23,7 +23,7 @@ export class ThreadsRepository {
     const threads = await this.threadsRepository.query(
       `select "thread".*, json_build_object(
         'id', "u".id,
-        'username', "u".name,
+        'name', "u".name,
         'password', "u".password
       ) as "user" from "thread" inner join "user" as "u" on "thread"."user_id" = "u"."id" where "thread"."id" = ${id}`,
     );
@@ -43,7 +43,7 @@ export class ThreadsRepository {
         "thread".*, 
         json_build_object(
           'id', "u".id,
-          'username', "u".name,
+          'name', "u".name,
           'password', "u".password
         ) as "user"
       from "thread" 

--- a/src/threads/repositories/threadsRepository.ts
+++ b/src/threads/repositories/threadsRepository.ts
@@ -25,7 +25,7 @@ export class ThreadsRepository {
         'id', "u".id,
         'name', "u".name,
         'password', "u".password
-      ) as "user" from "thread" inner join "user" as "u" on "thread"."user_id" = "u"."id" where "thread"."id" = ${id}`,
+      ) as "user" from "thread" inner join "user" as "u" on "thread"."userId" = "u"."id" where "thread"."id" = ${id}`,
     );
 
     return this.threadsRepository.create(threads)[0];
@@ -47,10 +47,10 @@ export class ThreadsRepository {
           'password', "u".password
         ) as "user"
       from "thread" 
-      inner join "user" as "u" on "thread"."user_id" = "u"."id"
+      inner join "user" as "u" on "thread"."userId" = "u"."id"
       where "thread"."title" like '%${search}%'
-      order by "thread"."created_at" ${createdAt} 
-      limit ${limit} offset ${page * limit}
+      order by "thread"."createdAt" ${createdAt} 
+      limit ${limit} offset ${(page - 1) * limit}
       `,
     );
 
@@ -58,7 +58,11 @@ export class ThreadsRepository {
   }
 
   async count() {
-    return this.threadsRepository.query('select count(*) from "thread"');
+    const result = await this.threadsRepository.query(
+      'select count(*) from "thread"',
+    );
+
+    return parseInt(result[0].count, 10);
   }
 
   async update(

--- a/src/threads/repositories/threadsRepository.ts
+++ b/src/threads/repositories/threadsRepository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Thread } from 'src/threads/entities/thread.entity';
+import { User } from 'src/users/entities/User.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
@@ -9,14 +10,15 @@ export class ThreadsRepository {
     @InjectRepository(Thread) private threadsRepository: Repository<Thread>,
   ) {}
 
-  async create(thread: Partial<Thread>): Promise<Thread> {
-    const newThread = this.threadsRepository.create(thread);
+  async create(
+    thread: Partial<Thread>,
+    user: User,
+  ): Promise<Thread | undefined> {
+    const result = await this.threadsRepository.query(
+      `insert into "thread" ("title", "content", "userId") values ('${thread.title}', '${thread.content}', ${user.id}) returning *`,
+    );
 
-    return this.threadsRepository.save(newThread);
-  }
-
-  async save(thread: Thread): Promise<Thread> {
-    return this.threadsRepository.save(thread);
+    return this.threadsRepository.create(result)[0];
   }
 
   async findOneById(id: number): Promise<Thread | undefined> {

--- a/src/threads/threads.module.ts
+++ b/src/threads/threads.module.ts
@@ -4,11 +4,12 @@ import { ThreadsService } from 'src/threads/threads.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Thread } from 'src/threads/entities/thread.entity';
 import { UsersModule } from 'src/users/users.module';
+import { ThreadsRepository } from 'src/threads/repositories/threadsRepository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Thread]), UsersModule],
   controllers: [ThreadsController],
-  providers: [ThreadsService],
-  exports: [ThreadsService, TypeOrmModule, UsersModule],
+  providers: [ThreadsService, ThreadsRepository],
+  exports: [ThreadsService, TypeOrmModule, UsersModule, ThreadsRepository],
 })
 export class ThreadsModule {}

--- a/src/threads/threads.service.ts
+++ b/src/threads/threads.service.ts
@@ -39,7 +39,7 @@ export class ThreadsService {
     const totalThreadsCount = await this.threadRepository.count();
 
     const threads = await this.threadRepository.findForPagination(
-      page || 0,
+      page || 1,
       limit || this.MAX_LIMIT,
       search ? search : '',
       'DESC',

--- a/src/threads/threads.service.ts
+++ b/src/threads/threads.service.ts
@@ -24,11 +24,7 @@ export class ThreadsService {
       throw new NotFoundException('User not found');
     }
 
-    await this.threadRepository.create({
-      title: createThreadDto.title,
-      content: createThreadDto.content,
-      user,
-    });
+    await this.threadRepository.create(createThreadDto, user);
   }
 
   async findOne(id: number) {

--- a/src/users/repositories/usersRepository.ts
+++ b/src/users/repositories/usersRepository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserSignUpDto } from 'src/auth/dto/user-signup.dto';
+import { User } from 'src/users/entities/User.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class UsersRepository {
+  constructor(
+    @InjectRepository(User) private readonly repository: Repository<User>,
+  ) {}
+
+  create(userSignUpDto: UserSignUpDto): Promise<User> {
+    const user = this.repository.create(userSignUpDto);
+
+    return this.repository.save(user);
+  }
+
+  async findByOneName(name: string): Promise<User> {
+    const user = await this.repository.query(
+      `select * from "user" where "name" = '${name}'`,
+    );
+
+    return user[0];
+  }
+
+  async findByOneId(id: number): Promise<User> {
+    const user = await this.repository.query(
+      `select * from "user" where "id" = '${id}'`,
+    );
+
+    return user[0];
+  }
+}

--- a/src/users/repositories/usersRepository.ts
+++ b/src/users/repositories/usersRepository.ts
@@ -10,10 +10,12 @@ export class UsersRepository {
     @InjectRepository(User) private readonly repository: Repository<User>,
   ) {}
 
-  create(userSignUpDto: UserSignUpDto): Promise<User> {
-    const user = this.repository.create(userSignUpDto);
+  async create(userSignUpDto: UserSignUpDto): Promise<User | undefined> {
+    const result = await this.repository.query(
+      `insert into "user" ("name", "password") values ('${userSignUpDto.name}', '${userSignUpDto.password}') returning *`,
+    );
 
-    return this.repository.save(user);
+    return this.repository.create(result)[0];
   }
 
   async findByOneName(name: string): Promise<User> {

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/users/entities/User.entity';
+import { UsersRepository } from 'src/users/repositories/usersRepository';
 import { UsersService } from 'src/users/users.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [],
-  providers: [UsersService],
+  providers: [UsersService, UsersRepository],
   exports: [UsersService, TypeOrmModule],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -18,7 +18,13 @@ export class UsersService {
       throw new ConflictException('User already exists');
     }
 
-    return this.usersRepository.create(signUpDto);
+    const newUser = await this.usersRepository.create(signUpDto);
+
+    if (!newUser) {
+      throw new ConflictException('Failed to create user');
+    }
+
+    return newUser;
   }
 
   async findOneByName(name: string): Promise<User> {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,24 +1,28 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { User } from './entities/User.entity';
-import { Repository } from 'typeorm';
 import { UserSignUpDto } from '../auth/dto/user-signup.dto';
+import { UsersRepository } from 'src/users/repositories/usersRepository';
 
 @Injectable()
 export class UsersService {
-  constructor(
-    @InjectRepository(User)
-    private usersRepository: Repository<User>,
-  ) {}
+  constructor(private usersRepository: UsersRepository) {}
 
   async create(signUpDto: UserSignUpDto): Promise<User> {
-    const user = this.usersRepository.create(signUpDto);
+    const user = await this.usersRepository.findByOneName(signUpDto.name);
 
-    return this.usersRepository.save(user);
+    if (user) {
+      throw new ConflictException('User already exists');
+    }
+
+    return this.usersRepository.create(signUpDto);
   }
 
   async findOneByName(name: string): Promise<User> {
-    const user = await this.usersRepository.findOneBy({ name });
+    const user = await this.usersRepository.findByOneName(name);
 
     if (!user) {
       throw new NotFoundException('User not found');
@@ -28,7 +32,7 @@ export class UsersService {
   }
 
   async findOneById(id: number): Promise<User> {
-    const user = await this.usersRepository.findOneBy({ id });
+    const user = await this.usersRepository.findByOneId(id);
 
     if (!user) {
       throw new NotFoundException('User not found');


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

> close #10 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### raw 쿼리로 repository 를 수정했습니다.
원래 typeorm repository 를 상속받아 repository 를 작성 할 수있지만, 버전이 올라가며 그기능이 삭제 된것 같습니다.

그래서 새로운 injectable 한 클래스를 만들고 typeorm repository 를 주입받아, 새로운 인터페이스로 작동되게 수정했습니다.

```ts
// 아래와 같이 직접 repository 를 주입받고 새로운 method 로 감싸 정의합니다.
export class FileRepository {
  constructor(
    @InjectRepository(File)
    private readonly fileRepository: Repository<File>,
  ) {}

  async create(thread: Partial<Thread>): Promise<Thread> {
    const newThread = this.threadsRepository

// ...
```

### all filter exception logger 정보 추가
어떤 에러가 났을때, log를 보면 500 error 로만 떴습니다.
정의한 all exception filter 에서 httpException 이 아니면 사용자에게 보내는 response 뿐 아니라 log 에도 똑같이 적용했었습니다.

개발의 편의를 위해 log 에 다음 두 가지 정보를 추가했습니다.
1. 에러 메세지
2. 에러 스택

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
