### PR TITLE
Feat: rbac 구현 및 적용

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,8 @@ import { Comment } from 'src/comments/entities/comment.entity';
 import { FileModule } from './file/file.module';
 import { File } from 'src/file/entities/file.entity';
 import { FileApiService } from './file-api/file-api.service';
+import { Role } from 'src/auth/entities/role.entity';
+import { Permission } from 'src/auth/entities/permission.entity';
 
 @Module({
   imports: [
@@ -30,7 +32,7 @@ import { FileApiService } from './file-api/file-api.service';
       database: process.env.DB_DATABASE,
       synchronize: true,
       logging: true,
-      entities: [Thread, User, Comment, File],
+      entities: [Thread, User, Comment, File, Role, Permission],
     }),
     ThreadsModule,
     UsersModule,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,12 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from 'src/users/users.module';
 import { SaltRoundsProvider } from './providers/providers';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Role } from 'src/auth/entities/role.entity';
+import { Permission } from 'src/auth/entities/permission.entity';
 
 @Module({
-  imports: [UsersModule],
+  imports: [UsersModule, TypeOrmModule.forFeature([Role, Permission])],
   controllers: [AuthController],
   providers: [AuthService, SaltRoundsProvider],
   exports: [AuthService],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -34,12 +34,15 @@ export class AuthService {
   async signIn(userSignInDto: UserSignInDto) {
     const { name, password } = userSignInDto;
 
-    const user = await this.usersService.findOneByName(name);
-    if (!user) {
+    const userInfo = await this.usersService.findOneByName(name);
+    if (!userInfo) {
       throw new NotFoundException('User not found');
     }
 
-    const isPasswordCorrect = await bcrypt.compare(password, user.password);
+    const isPasswordCorrect = await bcrypt.compare(
+      password,
+      userInfo.user.password,
+    );
     if (!isPasswordCorrect) {
       throw new ForbiddenException('Invalid credentials');
     }
@@ -50,6 +53,8 @@ export class AuthService {
       throw new Error('No secret found');
     }
 
-    return jwt.sign({ id: user.id }, secret, { expiresIn: '365d' });
+    return jwt.sign({ id: userInfo.user.id, roles: userInfo.roles }, secret, {
+      expiresIn: '365d',
+    });
   }
 }

--- a/src/auth/decorators/Roles.decorator.ts
+++ b/src/auth/decorators/Roles.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from '@nestjs/common';
+
+export enum Role {
+  Admin = 'admin',
+  Buyer = 'buyer',
+  User = 'user',
+}
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/entities/permission.entity.ts
+++ b/src/auth/entities/permission.entity.ts
@@ -1,0 +1,14 @@
+import { Role } from 'src/auth/entities/role.entity';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany } from 'typeorm';
+
+@Entity()
+export class Permission {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string;
+
+  @ManyToMany(() => Role, (role) => role.permissions)
+  roles: Role[];
+}

--- a/src/auth/entities/role.entity.ts
+++ b/src/auth/entities/role.entity.ts
@@ -1,0 +1,25 @@
+import { Permission } from 'src/auth/entities/permission.entity';
+import { User } from 'src/users/entities/User.entity';
+import {
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity()
+export class Role {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  name: string;
+
+  @ManyToMany(() => User, (user) => user.roles)
+  users: User[];
+
+  @ManyToMany(() => Permission, { eager: true })
+  @JoinTable()
+  permissions: Permission[];
+}

--- a/src/auth/guards/roles.guard.ts
+++ b/src/auth/guards/roles.guard.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from 'src/auth/decorators/Roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly configService: ConfigService,
+  ) {}
+  canActivate(context: ExecutionContext) {
+    const roles = this.reflector.get<string[]>(ROLES_KEY, context.getHandler());
+    if (!roles) {
+      return true;
+    }
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const { roles: userRoles } = user.roles;
+    if (this.matchRoles(roles, userRoles)) {
+      return true;
+    }
+
+    throw new UnauthorizedException('You do not have permission');
+  }
+
+  private matchRoles(roles: string[], userRoles: string[]) {
+    return roles.some((role) => userRoles?.includes(role));
+  }
+}

--- a/src/file/file.controller.ts
+++ b/src/file/file.controller.ts
@@ -22,6 +22,8 @@ import { FileService } from 'src/file/file.service';
 import { v4 } from 'uuid';
 import { ThreadsService } from '../threads/threads.service';
 import { FileDeleteDto } from './dtos/file-delete.dto';
+import { Role, Roles } from 'src/auth/decorators/Roles.decorator';
+import { RolesGuard } from 'src/auth/guards/roles.guard';
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller('file')
@@ -31,7 +33,8 @@ export class FileController {
     private readonly threadsService: ThreadsService,
   ) {}
 
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(Role.Buyer, Role.Admin)
   @Post('upload/:threadId')
   @UseInterceptors(
     FilesInterceptor('files', 10, {
@@ -85,7 +88,7 @@ export class FileController {
     return response.download(file.path, file.name);
   }
 
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard, RolesGuard)
   @Post(':threadId/delete')
   async deleteFiles(
     @Param('threadId', ParseIntPipe) threadId: number,

--- a/src/users/entities/User.entity.ts
+++ b/src/users/entities/User.entity.ts
@@ -1,9 +1,10 @@
 import { Thread } from 'src/threads/entities/thread.entity';
 import { Comment } from 'src/comments/entities/comment.entity';
 
-import { Column, Entity, OneToMany } from 'typeorm';
+import { Column, Entity, JoinTable, ManyToMany, OneToMany } from 'typeorm';
 import { File } from '../../file/entities/file.entity';
 import { BaseEntity } from '../../common/entities/base.entity';
+import { Role } from 'src/auth/entities/role.entity';
 
 @Entity()
 export class User extends BaseEntity {
@@ -21,4 +22,8 @@ export class User extends BaseEntity {
 
   @OneToMany(() => File, (file) => file.thread, { lazy: true })
   files: Promise<File[]>;
+
+  @ManyToMany(() => Role, (role) => role.users)
+  @JoinTable()
+  roles: Role[];
 }

--- a/src/users/repositories/usersRepository.ts
+++ b/src/users/repositories/usersRepository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Role } from 'src/auth/decorators/Roles.decorator';
 import { UserSignUpDto } from 'src/auth/dto/user-signup.dto';
 import { User } from 'src/users/entities/User.entity';
 import { Repository } from 'typeorm';
@@ -9,21 +10,56 @@ export class UsersRepository {
   constructor(
     @InjectRepository(User) private readonly repository: Repository<User>,
   ) {}
+  async create(
+    userSignUpDto: UserSignUpDto,
+    defaultRoles: Role[],
+  ): Promise<User | undefined> {
+    const queryRunner = this.repository.manager.connection.createQueryRunner();
 
-  async create(userSignUpDto: UserSignUpDto): Promise<User | undefined> {
-    const result = await this.repository.query(
-      `insert into "user" ("name", "password") values ('${userSignUpDto.name}', '${userSignUpDto.password}') returning *`,
-    );
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
 
-    return this.repository.create(result)[0];
+    try {
+      const rolesResult = await queryRunner.query(
+        `select id from "role" where "name" in ('${defaultRoles.join("','")}')`,
+      );
+
+      const result = await queryRunner.query(
+        `insert into "user" ("name", "password") values ('${userSignUpDto.name}', '${userSignUpDto.password}') returning *`,
+      );
+      const user = result[0];
+
+      for (const role of rolesResult) {
+        await queryRunner.query(
+          `insert into "user_roles_role" ("userId", "roleId") values (${user.id}, ${role.id})`,
+        );
+      }
+
+      await queryRunner.commitTransaction();
+      return user;
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
   }
 
-  async findByOneName(name: string): Promise<User> {
+  async findByOneName(name: string) {
+    const roleNamesByUser = await this.repository.query(
+      `select 
+        array_agg("role"."name") as roles
+      from "user"
+      left join "user_roles_role" on "user"."id" = "user_roles_role"."userId"
+      left join "role" on "role"."id" = "user_roles_role"."roleId"
+      where "user"."name" = '${name}'`,
+    );
+
     const user = await this.repository.query(
       `select * from "user" where "name" = '${name}'`,
     );
 
-    return user[0];
+    return { user: user[0], roles: roleNamesByUser[0] };
   }
 
   async findByOneId(id: number): Promise<User> {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,6 +6,7 @@ import {
 import { User } from './entities/User.entity';
 import { UserSignUpDto } from '../auth/dto/user-signup.dto';
 import { UsersRepository } from 'src/users/repositories/usersRepository';
+import { Role } from 'src/auth/decorators/Roles.decorator';
 
 @Injectable()
 export class UsersService {
@@ -18,7 +19,7 @@ export class UsersService {
       throw new ConflictException('User already exists');
     }
 
-    const newUser = await this.usersRepository.create(signUpDto);
+    const newUser = await this.usersRepository.create(signUpDto, [Role.Buyer]);
 
     if (!newUser) {
       throw new ConflictException('Failed to create user');
@@ -27,14 +28,14 @@ export class UsersService {
     return newUser;
   }
 
-  async findOneByName(name: string): Promise<User> {
-    const user = await this.usersRepository.findByOneName(name);
+  async findOneByName(name: string) {
+    const userInfo = await this.usersRepository.findByOneName(name);
 
-    if (!user) {
+    if (!userInfo) {
       throw new NotFoundException('User not found');
     }
 
-    return user;
+    return userInfo;
   }
 
   async findOneById(id: number): Promise<User> {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호
> close #21 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### permission, role 엔티티 추가
사용자마다 역할을 제공하기 위해 user <-> role <-> permission 관계를 설정했습니다.
유저는 많은 역할을 가지고, 역할도 많은 유저를 가지며, 권한역시 역할과 같은 관계이므로
모두 다대다 관계로 설정했습니다.

### guard 구현
먼저 signin 시에 token 에 role 정보를 제공합니다.
따라서 role 정보가 필요할 때 마다 token 을 추출 만 하면 되도록 했습니다.

역할을 구분해서 handler 접속 필터링을 위해 Roles Guard  구현을 했습니다.
Roles Guard 에 필터링할 역할 전달을 위해 setMetaData 로 구현한 Roles 데코레이터를 추가했습니다.

Roles Guard 는 먼저 Auth Guard 에서 token 로 추출한 user 정보를 request 에서 빼옵니다.
그리고 Roles 데코레이터가 요구하는 role 인지 user 의 role 과 비교합니다.

허가된 role 이라면 true 를 반환해 Guard 가 통과되게되고
아니라면 exception 필터로 넘어가도록 구현했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
