### PR TITLE
feat: refresh, access token 로직 작성

### DIFF
--- a/src/auth/decorators/get-userid.decorator.ts
+++ b/src/auth/decorators/get-userid.decorator.ts
@@ -1,6 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Request } from 'express';
 import * as jwt from 'jsonwebtoken';
+import { ACCESS_TOKEN_NAME } from 'src/common/constants';
 
 const getPayload = (token: string) => {
   try {
@@ -17,6 +18,6 @@ const getPayload = (token: string) => {
 export const GetUserId = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest<Request>();
-    return getPayload(request.cookies.token)?.id;
+    return getPayload(request.cookies?.[ACCESS_TOKEN_NAME])?.id;
   },
 );

--- a/src/auth/dto/user-signin-response.dto.ts
+++ b/src/auth/dto/user-signin-response.dto.ts
@@ -1,0 +1,10 @@
+import { IsString } from 'class-validator';
+
+export class SigninReponseDto {
+  @IsString()
+  accessToken: string;
+  @IsString()
+  refreshToken: string;
+  @IsString()
+  message: string;
+}

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -1,5 +1,6 @@
 import { CanActivate, Injectable, UnauthorizedException } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
+import { ACCESS_TOKEN_NAME } from 'src/common/constants';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -8,7 +9,7 @@ export class AuthGuard implements CanActivate {
     const token = this.extracFromCookie(request);
 
     if (!token) {
-      throw new UnauthorizedException('Please login to continue');
+      throw new UnauthorizedException('Empty access token');
     }
 
     try {
@@ -19,13 +20,13 @@ export class AuthGuard implements CanActivate {
 
       request.user = payload;
     } catch (error) {
-      throw new UnauthorizedException('Please login to continue');
+      throw new UnauthorizedException('Invalid access token');
     }
 
     return true;
   }
 
   private extracFromCookie(request: any) {
-    return request.cookies?.token;
+    return request.cookies?.[ACCESS_TOKEN_NAME];
   }
 }

--- a/src/auth/interceptors/checkAuthenticated.interceptor.ts
+++ b/src/auth/interceptors/checkAuthenticated.interceptor.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Request } from 'express';
 import { map } from 'rxjs';
+import { ACCESS_TOKEN_NAME } from 'src/common/constants';
 
 @Injectable()
 export class CheckAuthorizedInterceptor implements NestInterceptor {
@@ -20,6 +21,6 @@ export class CheckAuthorizedInterceptor implements NestInterceptor {
     );
   }
   private extracFromCookie(request: any) {
-    return request.cookies?.token;
+    return request.cookies?.[ACCESS_TOKEN_NAME];
   }
 }

--- a/src/auth/interceptors/clearJwtToken.interceptor.ts
+++ b/src/auth/interceptors/clearJwtToken.interceptor.ts
@@ -4,8 +4,9 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { map, Observable } from 'rxjs';
+import { ACCESS_TOKEN_NAME, REFRESH_TOKEN_NAME } from 'src/common/constants';
 
 @Injectable()
 export class ClearJwtTokenInterceptor implements NestInterceptor {
@@ -13,13 +14,11 @@ export class ClearJwtTokenInterceptor implements NestInterceptor {
     context: ExecutionContext,
     next: CallHandler<any>,
   ): Observable<any> | Promise<Observable<any>> {
-    const request = context.switchToHttp().getRequest<Request>();
     const response = context.switchToHttp().getResponse<Response>();
     return next.handle().pipe(
       map((data) => {
-        if (request.cookies?.token) {
-          response.clearCookie('token');
-        }
+        response.clearCookie(ACCESS_TOKEN_NAME);
+        response.clearCookie(REFRESH_TOKEN_NAME);
 
         return data;
       }),

--- a/src/auth/interceptors/setTokenCookie.interceptor.ts
+++ b/src/auth/interceptors/setTokenCookie.interceptor.ts
@@ -6,26 +6,31 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { map, Observable } from 'rxjs';
+import { SigninReponseDto } from 'src/auth/dto/user-signin-response.dto';
+import { ACCESS_TOKEN_NAME, REFRESH_TOKEN_NAME } from 'src/common/constants';
+
+export const cookieOptions = {
+  path: '/',
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+};
 
 @Injectable()
 export class SetTokenCookieInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     return next.handle().pipe(
-      map((data) => {
+      map((data: SigninReponseDto) => {
         const ctx = context.switchToHttp();
         const response = ctx.getResponse<Response>();
 
-        const { token, ...restData } = data;
+        const { accessToken, refreshToken, message } = data;
 
-        if (token) {
-          response.cookie('token', token, {
-            path: '/',
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production',
-          });
+        if (accessToken && refreshToken) {
+          response.cookie(ACCESS_TOKEN_NAME, accessToken, cookieOptions);
+          response.cookie(REFRESH_TOKEN_NAME, refreshToken, cookieOptions);
         }
 
-        return restData.message;
+        return message;
       }),
     );
   }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,1 +1,4 @@
 export const SALT_ROUNDS_TOKEN = 'SALT_ROUNDS';
+
+export const ACCESS_TOKEN_NAME = 'accessToken';
+export const REFRESH_TOKEN_NAME = 'refreshToken';


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호
close #24 

## 📝작업 내용

### access token, refresh token 으로 분리
기존에 하나의 token 으로 관리하던 로직을 보안을 위해 refresh token 으로 분리 했습니다.

먼저 로그인시 access, refresh token 을 발급 받습니다.
access token 이 만료 되기 전까지 인증을 통해 권한을 인가 받습니다.

access token 이 만료되면 error 를 보내고 refresh token 을 발급받는 api 에 요청을 보냅니다.
만약 refresh token 만료로 에러가 내려온다면

access token, refresh token 을 모두 삭제하고, signin 페이지로 리다이렉트 시킵니다.

프론트에서 따로 백엔드에 요청작업이 없게 하기 위해, 쿠키를 통해 token 통신합니다.
cookie 보안을 강화하기위해 http only 를 설정해 client 에서 js 로 접근 불가 하게 했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
